### PR TITLE
Reset OnCalendar event in Timer before adding new one.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -125,7 +125,7 @@ class mlocate::config (
     systemd::dropin_file{'period.conf':
       ensure  => $_dropin_file_ensure,
       unit    => 'mlocate-updatedb.timer',
-      content => "#Puppet installed\n[Timer]\nOnCalendar=${period}\n",
+      content => "#Puppet installed\n[Timer]\nOnCalendar=\nOnCalendar=${period}\n",
     }
 
     if $ensure {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -113,6 +113,7 @@ describe 'mlocate' do
           it { is_expected.not_to contain_file('/etc/cron.d/mlocate-puppet.cron') }
           it { is_expected.not_to contain_file('/etc/cron.daily/mlocate') }
           it { is_expected.to contain_systemd__dropin_file('period.conf').with_ensure('present') }
+          it { is_expected.to contain_systemd__dropin_file('period.conf').with_content(%r{^OnCalendar=$}) }
           it { is_expected.to contain_systemd__dropin_file('period.conf').with_content(%r{^OnCalendar=weekly$}) }
           it { is_expected.to contain_service('mlocate-updatedb.timer') }
           it { is_expected.to contain_service('mlocate-updatedb.timer').with_ensure(true) }


### PR DESCRIPTION
A systemd drop file with

```ini
[Timer]
OnCalendar=weekly
```

was being added. This has the undesirable consequnce that
an additonal timer slot is added rather than replacing
the existing default OnCalendar.
