### PR TITLE
Give example a title in strings doc

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -22,9 +22,10 @@ mlocate class , install and configure mlocate
 
 #### Examples
 
-##### 
+##### Simple Case
 
 ```puppet
+
 class{'mlocate':
   prunepaths   => ['/afs', '/mnt' ],
   prunefs      => ['afs', 'fuse'],
@@ -94,15 +95,11 @@ Path to a cron file entry to be purged.
 
 Default value: `undef`
 
-##### `fore_updatedb`
-
-Should puppet run updatedb if no database already exists.
-
 ##### `force_updatedb`
 
 Data type: `Boolean`
 
-
+Should puppet run updatedb if no database already exists.
 
 Default value: `false`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,8 @@
 #
 # @summary mlocate class , install and configure mlocate
 #
-# @example
+# @example Simple Case
+#
 #  class{'mlocate':
 #    prunepaths   => ['/afs', '/mnt' ],
 #    prunefs      => ['afs', 'fuse'],
@@ -17,7 +18,7 @@
 # @param prunenames List of directory or files names to match adn not include.
 # @param period Should the update interval be daily, weekly, monthly or infinite.
 # @param package_cron Path to a cron file entry to be purged.
-# @param fore_updatedb Should puppet run updatedb if no database already exists.
+# @param force_updatedb Should puppet run updatedb if no database already exists.
 #
 class mlocate (
   Boolean                                     $ensure = true,


### PR DESCRIPTION
#### Pull Request (PR) description

The example in the strings generated output had an empty
heading due to lack of heading for the example.

Correct `force_updatedb` parameter name in strings documentation.