### PR TITLE
Add username field to /etc/cron.d entries / introduce puppet/cron as new dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,3 +2,4 @@ fixtures:
   repositories:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib"
     systemd: "https://github.com/camptocamp/puppet-systemd"
+    cron: "https://github.com/voxpupuli/puppet-cron"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -87,7 +87,7 @@ class mlocate::config (
       owner   => root,
       group   => root,
       mode    => '0644',
-      content => "#Puppet installed\n${_cron_time} /usr/local/bin/mlocate-wrapper\n",
+      content => "#Puppet installed\n${_cron_time} root /usr/local/bin/mlocate-wrapper\n",
     }
 
     $_updatedb_command = '/usr/local/bin/mlocate-wrapper'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -47,7 +47,10 @@ class mlocate::config (
   }
 
   if $periodic_method == 'cron' {
-    file{'/usr/local/bin/mlocate-wrapper':
+
+    $_updatedb_command = '/usr/local/bin/mlocate-wrapper'
+
+    file{$_updatedb_command:
       ensure => $_file_ensure,
       owner  => root,
       group  => root,
@@ -57,44 +60,72 @@ class mlocate::config (
 
     case $period {
       'daily': {
-        $_cron_time   = "${fqdn_rand(59,'mlocate')} ${fqdn_rand(24,'mlocate')} * * *"
-        $_cron_ensure = 'present'
+        $_cron_ensure = true
+        $_minute      = "${fqdn_rand(59,'mlocate')}"
+        $_hour        = "${fqdn_rand(24,'mlocate')}"
+        $_date        = '*'
+        $_month       = '*'
+        $_weekday     = '*'
       }
       'weekly': {
-        $_cron_time   = "${fqdn_rand(59,'mlocate')} ${fqdn_rand(24,'mlocate')} * * ${fqdn_rand(7,'mlocate')}"
-        $_cron_ensure = 'present'
+        $_cron_ensure = true
+        $_minute      = "${fqdn_rand(59,'mlocate')}"
+        $_hour        = "${fqdn_rand(24,'mlocate')}"
+        $_date        = '*'
+        $_month       = '*'
+        $_weekday     = "${fqdn_rand(7,'mlocate')}"
       }
       'monthly': {
-        $_cron_time   = "${fqdn_rand(59,'mlocate')} ${fqdn_rand(24,'mlocate')} ${fqdn_rand(28,'mlocate')} * *"
-        $_cron_ensure = 'present'
+        $_cron_ensure = true
+        $_minute      = "${fqdn_rand(59,'mlocate')}"
+        $_hour        = "${fqdn_rand(24,'mlocate')}"
+        $_date        = "${fqdn_rand(28,'mlocate')}"
+        $_month       = '*'
+        $_weekday     = '*'
+
       }
       'infinite': {
-        $_cron_time   = 'irrelevent'
-        $_cron_ensure = 'absent'
+        $_cron_ensure = false
+        $_minute      = undef
+        $_hour        = undef
+        $_date        = undef
+        $_month       = undef
+        $_weekday     = undef
       }
       default: {
         fail('Undefined period')
       }
     }
 
-    $_cron_file_ensure = $ensure ? {
-      true  => $_cron_ensure,
-      false => 'absent',
-    }
-
+    # Remove old filename that cron::job does not support with a '.' in
+    # Last in version 1.0.0
     file{'/etc/cron.d/mlocate-puppet.cron':
-      ensure  => $_cron_file_ensure,
-      owner   => root,
-      group   => root,
-      mode    => '0644',
-      content => "#Puppet installed\n${_cron_time} root /usr/local/bin/mlocate-wrapper\n",
+      ensure => 'absent',
     }
 
-    $_updatedb_command = '/usr/local/bin/mlocate-wrapper'
+    if $_cron_ensure and $ensure {
+      $_cron_job_ensure = 'present'
+    } else {
+      $_cron_job_ensure = 'absent'
+    }
+
+    cron::job{'mlocate-puppet':
+      ensure      => $_cron_job_ensure,
+      command     => '/usr/local/bin/mlocate-wrapper',
+      user        => 'root',
+      minute      => $_minute,
+      hour        => $_hour,
+      date        => $_date,
+      weekday     => $_weekday,
+      month       => $_month,
+      description => 'Update mlocate database',
+    }
 
     # End of cron based systemd
 
   } elsif $periodic_method == 'timer' {
+
+    $_updatedb_command = '/usr/bin/systemctl start mlocate-updatedb.service'
 
     # daily is default so no dropin required.
     case $period {
@@ -135,9 +166,6 @@ class mlocate::config (
         enable => $_timer_active,
       }
     }
-
-    $_updatedb_command = '/usr/bin/systemctl start mlocate-updatedb.service'
-
   }
 
   # Run updatedb if no database present.

--- a/metadata.json
+++ b/metadata.json
@@ -20,6 +20,10 @@
     {
       "name": "camptocamp-systemd",
       "version_requirement": ">= 2.6.0 < 3.0.0"
+    },
+    {
+      "name": "puppet-cron",
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     }
   ],
   "requirements": [

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -39,17 +39,26 @@ describe 'mlocate' do
 
         case facts[:os]['release']['major']
         when '6', '7'
+          it { is_expected.to contain_file('/etc/cron.d/mlocate-puppet.cron').with_ensure('absent') }
           it { is_expected.to contain_file('/etc/cron.daily/mlocate') }
           it { is_expected.to contain_file('/etc/cron.daily/mlocate').with_content(%r{^#.*clobbered.*$}) }
-          it { is_expected.to contain_file('/etc/cron.d/mlocate-puppet.cron') }
-          it { is_expected.to contain_file('/etc/cron.d/mlocate-puppet.cron').with_content(%r{^\d\d? \d\d? \* \* \* root /usr/local/bin/mlocate-wrapper$}) }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_ensure('present') }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_minute(%r{^\d\d?}) }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_hour(%r{^\d\d?}) }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_date('*') }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_weekday('*') }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_month('*') }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_user('root') }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_command('/usr/local/bin/mlocate-wrapper') }
+
           it { is_expected.to contain_file('/usr/local/bin/mlocate-wrapper') }
           it { is_expected.to contain_file('/usr/local/bin/mlocate-wrapper').with_source('puppet:///modules/mlocate/mlocate-wrapper') }
           it { is_expected.not_to contain_systemd__dropin_file('period.conf') }
           it { is_expected.not_to contain_service('mlocate-updatedb.timer') }
         else
-          it { is_expected.not_to contain_file('/etc/cron.daily/mlocate') }
           it { is_expected.not_to contain_file('/etc/cron.d/mlocate-puppet.cron') }
+          it { is_expected.not_to contain_file('/etc/cron.daily/mlocate') }
+          it { is_expected.not_to contain_cron__job('mlocate-puppet') }
           it { is_expected.not_to contain_file('/usr/local/bin/mlocate-wrapper') }
           it { is_expected.to contain_systemd__dropin_file('period.conf').with_ensure('absent') }
           it { is_expected.to contain_service('mlocate-updatedb.timer') }
@@ -82,13 +91,20 @@ describe 'mlocate' do
         case facts[:os]['release']['major']
         when '6', '7'
           it { is_expected.to contain_file('/usr/local/bin/mlocate-wrapper') }
-          it { is_expected.to contain_file('/etc/cron.d/mlocate-puppet.cron').with_content(%r{^\d\d? \d\d? \* \* \* root /usr/local/bin/mlocate-wrapper$}) }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_ensure('present') }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_minute(%r{^\d\d?}) }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_hour(%r{^\d\d?}) }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_date('*') }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_weekday('*') }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_month('*') }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_user('root') }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_command('/usr/local/bin/mlocate-wrapper') }
           it { is_expected.to contain_file('/etc/cron.daily/mlocate').with_content(%r{^#.*clobbered.*$}) }
           it { is_expected.not_to contain_systemd__dropin_file('period.conf') }
           it { is_expected.not_to contain_service('mlocate-updatedb.timer') }
         else
           it { is_expected.not_to contain_file('/usr/local/bin/mlocate-wrapper') }
-          it { is_expected.not_to contain_file('/etc/cron.d/mlocate-puppet.cron') }
+          it { is_expected.not_to contain_cron__job('mlocate-puppet') }
           it { is_expected.not_to contain_file('/etc/cron.daily/mlocate') }
           it { is_expected.to contain_systemd__dropin_file('period.conf').with_ensure('absent') }
           it { is_expected.to contain_service('mlocate-updatedb.timer') }
@@ -105,12 +121,19 @@ describe 'mlocate' do
 
         case facts[:os]['release']['major']
         when '6', '7'
-          it { is_expected.to contain_file('/etc/cron.d/mlocate-puppet.cron').with_content(%r{^\d\d? \d\d? \* \* \d\d? root /usr/local/bin/mlocate-wrapper$}) }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_ensure('present') }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_minute(%r{^\d\d?}) }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_hour(%r{^\d\d?}) }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_date('*') }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_weekday(%r{\d}) }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_month('*') }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_user('root') }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_command('/usr/local/bin/mlocate-wrapper') }
           it { is_expected.to contain_file('/etc/cron.daily/mlocate').with_content(%r{^#.*clobbered.*$}) }
           it { is_expected.not_to contain_systemd__dropin_file('period.conf') }
           it { is_expected.not_to contain_service('mlocate-updatedb.timer') }
         else
-          it { is_expected.not_to contain_file('/etc/cron.d/mlocate-puppet.cron') }
+          it { is_expected.not_to contain_cron__job('mlocate-puppet') }
           it { is_expected.not_to contain_file('/etc/cron.daily/mlocate') }
           it { is_expected.to contain_systemd__dropin_file('period.conf').with_ensure('present') }
           it { is_expected.to contain_systemd__dropin_file('period.conf').with_content(%r{^OnCalendar=$}) }
@@ -129,12 +152,19 @@ describe 'mlocate' do
 
         case facts[:os]['release']['major']
         when '6', '7'
-          it { is_expected.to contain_file('/etc/cron.d/mlocate-puppet.cron').with_content(%r{^\d\d? \d\d? \d\d? \* \* root /usr/local/bin/mlocate-wrapper$}) }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_ensure('present') }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_minute(%r{^\d\d?}) }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_hour(%r{^\d\d?}) }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_date(%r{^\d\d?}) }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_weekday('*') }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_month('*') }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_user('root') }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_command('/usr/local/bin/mlocate-wrapper') }
           it { is_expected.to contain_file('/etc/cron.daily/mlocate').with_content(%r{^#.*clobbered.*$}) }
           it { is_expected.not_to contain_systemd__dropin_file('period.conf') }
           it { is_expected.not_to contain_service('mlocate-updatedb.timer') }
         else
-          it { is_expected.not_to contain_file('/etc/cron.d/mlocate-puppet.cron') }
+          it { is_expected.not_to contain_cron__job('mlocate-puppet') }
           it { is_expected.not_to contain_file('/etc/cron.daily/mlocate') }
           it { is_expected.to contain_systemd__dropin_file('period.conf').with_ensure('present') }
           it { is_expected.to contain_systemd__dropin_file('period.conf').with_content(%r{^OnCalendar=monthly$}) }
@@ -152,12 +182,12 @@ describe 'mlocate' do
 
         case facts[:os]['release']['major']
         when '6', '7'
-          it { is_expected.to contain_file('/etc/cron.d/mlocate-puppet.cron').with_ensure('absent') }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_ensure('absent') }
           it { is_expected.to contain_file('/etc/cron.daily/mlocate').with_content(%r{^#.*clobbered.*$}) }
           it { is_expected.not_to contain_systemd__dropin_file('period.conf') }
           it { is_expected.not_to contain_service('mlocate-updatedb.timer') }
         else
-          it { is_expected.not_to contain_file('/etc/cron.d/mlocate-puppet.cron') }
+          it { is_expected.not_to contain_cron__job('mlocate-puppet') }
           it { is_expected.not_to contain_file('/etc/cron.daily/mlocate') }
           it { is_expected.to contain_systemd__dropin_file('period.conf').with_ensure('absent') }
           it { is_expected.to contain_service('mlocate-updatedb.timer') }
@@ -196,11 +226,11 @@ describe 'mlocate' do
         case facts[:os]['release']['major']
         when '6', '7'
           it { is_expected.not_to contain_systemd__dropin_file('period.conf') }
-          it { is_expected.to contain_file('/etc/cron.d/mlocate-puppet.cron').with_ensure('absent') }
+          it { is_expected.to contain_cron__job('mlocate-puppet').with_ensure('absent') }
           it { is_expected.to contain_file('/usr/local/bin/mlocate-wrapper').with_ensure('absent') }
         else
           it { is_expected.to contain_systemd__dropin_file('period.conf').with_ensure('absent') }
-          it { is_expected.not_to contain_file('/etc/cron.d/mlocate-puppet.cron') }
+          it { is_expected.not_to contain_cron__job('mlocate-puppet') }
           it { is_expected.not_to contain_file('/usr/local/bin/mlocate-wrapper') }
         end
       end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -42,7 +42,7 @@ describe 'mlocate' do
           it { is_expected.to contain_file('/etc/cron.daily/mlocate') }
           it { is_expected.to contain_file('/etc/cron.daily/mlocate').with_content(%r{^#.*clobbered.*$}) }
           it { is_expected.to contain_file('/etc/cron.d/mlocate-puppet.cron') }
-          it { is_expected.to contain_file('/etc/cron.d/mlocate-puppet.cron').with_content(%r{^\d\d? \d\d? \* \* \* /usr/local/bin/mlocate-wrapper$}) }
+          it { is_expected.to contain_file('/etc/cron.d/mlocate-puppet.cron').with_content(%r{^\d\d? \d\d? \* \* \* root /usr/local/bin/mlocate-wrapper$}) }
           it { is_expected.to contain_file('/usr/local/bin/mlocate-wrapper') }
           it { is_expected.to contain_file('/usr/local/bin/mlocate-wrapper').with_source('puppet:///modules/mlocate/mlocate-wrapper') }
           it { is_expected.not_to contain_systemd__dropin_file('period.conf') }
@@ -82,7 +82,7 @@ describe 'mlocate' do
         case facts[:os]['release']['major']
         when '6', '7'
           it { is_expected.to contain_file('/usr/local/bin/mlocate-wrapper') }
-          it { is_expected.to contain_file('/etc/cron.d/mlocate-puppet.cron').with_content(%r{^\d\d? \d\d? \* \* \* /usr/local/bin/mlocate-wrapper$}) }
+          it { is_expected.to contain_file('/etc/cron.d/mlocate-puppet.cron').with_content(%r{^\d\d? \d\d? \* \* \* root /usr/local/bin/mlocate-wrapper$}) }
           it { is_expected.to contain_file('/etc/cron.daily/mlocate').with_content(%r{^#.*clobbered.*$}) }
           it { is_expected.not_to contain_systemd__dropin_file('period.conf') }
           it { is_expected.not_to contain_service('mlocate-updatedb.timer') }
@@ -105,7 +105,7 @@ describe 'mlocate' do
 
         case facts[:os]['release']['major']
         when '6', '7'
-          it { is_expected.to contain_file('/etc/cron.d/mlocate-puppet.cron').with_content(%r{^\d\d? \d\d? \* \* \d\d? /usr/local/bin/mlocate-wrapper$}) }
+          it { is_expected.to contain_file('/etc/cron.d/mlocate-puppet.cron').with_content(%r{^\d\d? \d\d? \* \* \d\d? root /usr/local/bin/mlocate-wrapper$}) }
           it { is_expected.to contain_file('/etc/cron.daily/mlocate').with_content(%r{^#.*clobbered.*$}) }
           it { is_expected.not_to contain_systemd__dropin_file('period.conf') }
           it { is_expected.not_to contain_service('mlocate-updatedb.timer') }
@@ -129,7 +129,7 @@ describe 'mlocate' do
 
         case facts[:os]['release']['major']
         when '6', '7'
-          it { is_expected.to contain_file('/etc/cron.d/mlocate-puppet.cron').with_content(%r{^\d\d? \d\d? \d\d? \* \* /usr/local/bin/mlocate-wrapper$}) }
+          it { is_expected.to contain_file('/etc/cron.d/mlocate-puppet.cron').with_content(%r{^\d\d? \d\d? \d\d? \* \* root /usr/local/bin/mlocate-wrapper$}) }
           it { is_expected.to contain_file('/etc/cron.daily/mlocate').with_content(%r{^#.*clobbered.*$}) }
           it { is_expected.not_to contain_systemd__dropin_file('period.conf') }
           it { is_expected.not_to contain_service('mlocate-updatedb.timer') }


### PR DESCRIPTION


#### Pull Request (PR) description
The format of files in /etc/cron.d should follow

```
# Example of job definition:
# .---------------- minute (0 - 59)
# |  .------------- hour (0 - 23)
# |  |  .---------- day of month (1 - 31)
# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
# |  |  |  |  |
# *  *  *  *  * user-name  command to be executed
```

This module was deploying `/etc/cron.d/mlocate-puppet.cron` with

```
29 13 * * 3 /usr/local/bin/mlocate-wrapper
```

resulting in cronlog of

```
Feb 11 08:51:46 aiadm98 crond[29278]: (CRON) bad command (/etc/cron.d/mlocate-puppet.cron)
```

The `root` user is now added as the 6th field to correct this mis-configuration.