### PR TITLE
Don't index /var/cache/{dnf,yum} on RedHat systems

### DIFF
--- a/data/RedHat-7.yaml
+++ b/data/RedHat-7.yaml
@@ -9,5 +9,6 @@ mlocate::prunefs:
 
 mlocate::prunepaths:
   - /mnt
+  - /var/cache/yum
   - /var/lib/yum/yumdb
   - /var/lib/ceph

--- a/data/RedHat-8.yaml
+++ b/data/RedHat-8.yaml
@@ -7,6 +7,8 @@ mlocate::prunefs:
 
 mlocate::prunepaths:
   - /mnt
+  - /var/cache/dnf
+  - /var/cache/yum
   - /var/lib/ceph
   - /var/lib/dnf/yumdb
   - /var/lib/yum/yumdb

--- a/data/RedHat-9.yaml
+++ b/data/RedHat-9.yaml
@@ -6,7 +6,9 @@ mlocate::prunefs:
 
 mlocate::prunepaths:
   - /mnt
+  - /var/cache/dnf
   - /var/cache/fscache
+  - /var/cache/yum
   - /var/lib/ceph
   - /var/lib/dnf/yumdb
   - /var/lib/yum/yumdb

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -21,14 +21,14 @@ describe 'mlocate' do
         case facts[:os]['release']['major']
         when '7'
           it { is_expected.to contain_file('/etc/updatedb.conf').with_content(%r{^PRUNEFS\s+=\s+"9p afs anon_inodefs auto autofs bdev binfmt_misc ceph cgroup cifs coda configfs cpuset debugfs devpts ecryptfs exofs fuse fuse.ceph fuse.glusterfs fuse.sshfs fusectl gfs gfs2 gpfs hugetlbfs inotifyfs iso9660 jffs2 lustre mqueue ncpfs nfs nfs4 nfsd pipefs proc ramfs rootfs rpc_pipefs securityfs selinuxfs sfs sockfs sysfs tmpfs ubifs udf usbfs"$}) }
-          it { is_expected.to contain_file('/etc/updatedb.conf').with_content(%r{^PRUNEPATHS\s+=\s+"/afs /media /mnt /net /sfs /tmp /udev /var/cache/ccache /var/lib/ceph /var/lib/yum/yumdb /var/spool/cups /var/spool/squid /var/tmp"$}) }
+          it { is_expected.to contain_file('/etc/updatedb.conf').with_content(%r{^PRUNEPATHS\s+=\s+"/afs /media /mnt /net /sfs /tmp /udev /var/cache/ccache /var/cache/yum /var/lib/ceph /var/lib/yum/yumdb /var/spool/cups /var/spool/squid /var/tmp"$}) }
         else
           it { is_expected.to contain_file('/etc/updatedb.conf').with_content(%r{^PRUNEFS\s+=\s+"9p afs anon_inodefs auto autofs bdev binfmt_misc ceph cgroup cifs coda configfs cpuset debugfs devpts ecryptfs exofs fuse fuse.ceph fuse.sshfs fusectl gfs gfs2 gpfs hugetlbfs inotifyfs iso9660 jffs2 lustre mqueue ncpfs nfs nfs4 nfsd pipefs proc ramfs rootfs rpc_pipefs securityfs selinuxfs sfs sockfs sysfs tmpfs ubifs udf usbfs"$}) }
 
           if facts[:os]['release']['major'] == '8'
-            it { is_expected.to contain_file('/etc/updatedb.conf').with_content(%r{^PRUNEPATHS\s+=\s+"/afs /media /mnt /net /sfs /tmp /udev /var/cache/ccache /var/lib/ceph /var/lib/dnf/yumdb /var/lib/yum/yumdb /var/spool/cups /var/spool/squid /var/tmp"$}) }
+            it { is_expected.to contain_file('/etc/updatedb.conf').with_content(%r{^PRUNEPATHS\s+=\s+"/afs /media /mnt /net /sfs /tmp /udev /var/cache/ccache /var/cache/dnf /var/cache/yum /var/lib/ceph /var/lib/dnf/yumdb /var/lib/yum/yumdb /var/spool/cups /var/spool/squid /var/tmp"$}) }
           else
-            it { is_expected.to contain_file('/etc/updatedb.conf').with_content(%r{^PRUNEPATHS\s+=\s+"/afs /media /mnt /net /sfs /sysroot/ostree/deploy /tmp /udev /var/cache/ccache /var/cache/fscache /var/lib/ceph /var/lib/dnf/yumdb /var/lib/mock /var/lib/yum/yumdb /var/spool/cups /var/spool/squid /var/tmp"$}) }
+            it { is_expected.to contain_file('/etc/updatedb.conf').with_content(%r{^PRUNEPATHS\s+=\s+"/afs /media /mnt /net /sfs /sysroot/ostree/deploy /tmp /udev /var/cache/ccache /var/cache/dnf /var/cache/fscache /var/cache/yum /var/lib/ceph /var/lib/dnf/yumdb /var/lib/mock /var/lib/yum/yumdb /var/spool/cups /var/spool/squid /var/tmp"$}) }
           end
         end
 


### PR DESCRIPTION
#### Pull Request (PR) description
The dnf/yum caches don't really contain information folks would be searching for indirectly.  There really isn't any value in indexing them.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
