### PR TITLE
Support plocate alternative to mlocate

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,22 +16,26 @@
 <a id="module-description"></a>
 ## Module Description
 
-* Install mlocate package
+* Install mlocate or plocate package
 * Configures `/etc/updatedb.conf`
-* Maintains a cron or timer to run mlocate.
+* Maintains a cron or timer to run mlocate or plocate.
 
 <a id="setup"></a>
 ## Setup
 
-Install mlocate and configure with default configuration.
+Install mlocate or plocate and configure with default configuration.
 ```puppet
 include mlocate
 ```
+
+Fedora 37 and newer will install plocate always since mlocate will
+be obsoleted by the plocate RPM allways.
 
 Configure everything we can.
 ```puppet
 class{'mlocate':
   ensure            => true,
+  locate            => 'plocate',
   prunefs           => ['9p', 'afs', 'autofs', 'bdev'],
   prune_bind_mounts => true,
   prunenames        => ['.git', 'CVS'],
@@ -54,10 +58,9 @@ mlocate::prunepaths:
   - /cvmfs
 ```
 
-If you wish to switch to `plocate` instead you can use the `package_names` parameter to switch to that implementation instead.
+If you wish to switch to `plocate` instead you can use the `locate` parameter to switch to that implementation instead.
 
 ```yaml
 ---
-mlocate::package_names:
-  - plocate
+mlocate::locate: plocate
 ```

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -8,7 +8,7 @@
 
 #### Public Classes
 
-* [`mlocate`](#mlocate): mlocate class, install and configure mlocate
+* [`mlocate`](#mlocate): mlocate class, install and configure mlocate or plocate
 
 #### Private Classes
 
@@ -19,7 +19,7 @@
 
 ### <a name="mlocate"></a>`mlocate`
 
-mlocate class, install and configure mlocate
+mlocate class, install and configure mlocate or plocate
 
 #### Examples
 
@@ -36,11 +36,20 @@ class{'mlocate':
 }
 ```
 
+##### Use plocate rather than mlocate
+
+```puppet
+class{ 'mlocate':
+  locate => 'plocate',
+}
+```
+
 #### Parameters
 
 The following parameters are available in the `mlocate` class:
 
 * [`package_names`](#-mlocate--package_names)
+* [`locate`](#-mlocate--locate)
 * [`ensure`](#-mlocate--ensure)
 * [`prunefs`](#-mlocate--prunefs)
 * [`prune_bind_mounts`](#-mlocate--prune_bind_mounts)
@@ -52,11 +61,17 @@ The following parameters are available in the `mlocate` class:
 
 ##### <a name="-mlocate--package_names"></a>`package_names`
 
-Data type: `Array[String[1]]`
+Data type: `Optional[Array[String[1]]]`
 
-List of packages to track
+Deprecated
 
-Default value: `['mlocate',]`
+Default value: `undef`
+
+##### <a name="-mlocate--locate"></a>`locate`
+
+Data type: `Enum['mlocate','plocate']`
+
+Use plocate or mlocate, default per OS in hiera
 
 ##### <a name="-mlocate--ensure"></a>`ensure`
 

--- a/data/RedHat-36.yaml
+++ b/data/RedHat-36.yaml
@@ -1,0 +1,23 @@
+---
+
+mlocate::prunefs:
+  - ceph
+  - fuse.sshfs
+  - fuse.ceph
+
+mlocate::prunepaths:
+  - /mnt
+  - /var/cache/dnf
+  - /var/cache/fscache
+  - /var/cache/yum
+  - /var/lib/ceph
+  - /var/lib/dnf/yumdb
+  - /var/lib/yum/yumdb
+  - /var/lib/mock
+  - /sysroot/ostree/deploy
+
+mlocate::prunenames:
+  - '{arch}'
+  - .arch-ids
+  - .bzr
+  - CVS

--- a/data/RedHat-37.yaml
+++ b/data/RedHat-37.yaml
@@ -1,0 +1,25 @@
+---
+
+mlocate::locate: plocate
+
+mlocate::prunefs:
+  - ceph
+  - fuse.sshfs
+  - fuse.ceph
+
+mlocate::prunepaths:
+  - /mnt
+  - /var/cache/dnf
+  - /var/cache/fscache
+  - /var/cache/yum
+  - /var/lib/ceph
+  - /var/lib/dnf/yumdb
+  - /var/lib/yum/yumdb
+  - /var/lib/mock
+  - /sysroot/ostree/deploy
+
+mlocate::prunenames:
+  - '{arch}'
+  - .arch-ids
+  - .bzr
+  - CVS

--- a/data/RedHat-38.yaml
+++ b/data/RedHat-38.yaml
@@ -1,0 +1,25 @@
+---
+
+mlocate::locate: plocate
+
+mlocate::prunefs:
+  - ceph
+  - fuse.sshfs
+  - fuse.ceph
+
+mlocate::prunepaths:
+  - /mnt
+  - /var/cache/dnf
+  - /var/cache/fscache
+  - /var/cache/yum
+  - /var/lib/ceph
+  - /var/lib/dnf/yumdb
+  - /var/lib/yum/yumdb
+  - /var/lib/mock
+  - /sysroot/ostree/deploy
+
+mlocate::prunenames:
+  - '{arch}'
+  - .arch-ids
+  - .bzr
+  - CVS

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -8,6 +8,8 @@ lookup_options:
   mlocate::prunepaths:
     merge: unique
 
+mlocate::locate: mlocate
+
 mlocate::prunenames:
   - .git
   - .hg

--- a/data/os_name/Fedora.yaml
+++ b/data/os_name/Fedora.yaml
@@ -1,0 +1,3 @@
+---
+
+mlocate::locate: plocate

--- a/data/os_name/Fedora.yaml
+++ b/data/os_name/Fedora.yaml
@@ -1,3 +1,0 @@
----
-
-mlocate::locate: plocate

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,13 +6,25 @@
 class mlocate::install (
   $package_names = $mlocate::package_names,
   $ensure = $mlocate::ensure,
+  $locate = $mlocate::locate,
 ) {
   $_pkg_ensure = $ensure ? {
     true  => 'present',
     false => 'absent',
   }
 
-  package { $package_names:
+  # Remove other package
+  $_other = $locate ? {
+    'mlocate' => 'plocate',
+    default   => 'mlocate'
+  }
+
+  package { $_other:
+    ensure => 'absent',
+    before => Package[$locate],
+  }
+
+  package { $locate:
     ensure => $_pkg_ensure,
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -42,6 +42,13 @@
       ]
     },
     {
+      "operatingsystem": "Fedora",
+      "operatingsystemrelease": [
+        "36"
+      ]
+    },
+
+    {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7",

--- a/metadata.json
+++ b/metadata.json
@@ -44,7 +44,9 @@
     {
       "operatingsystem": "Fedora",
       "operatingsystemrelease": [
-        "36"
+        "36",
+        "37",
+        "38"
       ]
     },
 

--- a/metadata.json
+++ b/metadata.json
@@ -49,7 +49,6 @@
         "38"
       ]
     },
-
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [


### PR DESCRIPTION
#### Pull Request (PR) description

* Declare Fedora 36 support.
* The parameter `mlocate_packages` is deprecated.

Setting `mlocate_packages` to `plocate` or anything other than
the default `mlocate` never worked anyway.

Install and use **plocate** always on Fedora 37 and 38.

While **plocate** has been available in EL8 or Fedora 36 in Fedora 37 and newer the **plocate** RPM obsoletes
the **mlocate** package.

The default for EL8, EL9 and Fedora 36 remains **mlocate** however the new parameter `locate` can be set to `plocate` to install and configure `plocate`

* https://fedoraproject.org/wiki/Changes/Plocate_as_the_default_locate_implementation
