### PR TITLE
fix tests

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -45,7 +45,7 @@ describe 'mlocate' do
         when 'RedHat', 'Archlinux'
           it { is_expected.to contain_file('/etc/updatedb.conf').with_content(%r{^PRUNEPATHS\s=\s"/afs\s.*\s/var/tmp"$}) }
         else
-          it { is_expected.to contain_file('/etc/updatedb.conf').with_content(%r{^PRUNEPATHS\s=\s"/media\s.*\s/var/spool"$}) }
+          it { is_expected.to contain_file('/etc/updatedb.conf').with_content(%r{^PRUNEPATHS\s=\s".*/media\s.*\s/var/spool"$}) }
         end
 
         case facts[:os]['family']


### PR DESCRIPTION
fixes tests for modulesync 7.0.0
/media isnt necessarily the first value in prunepath 
see: https://github.com/voxpupuli/puppet-mlocate/actions/runs/7221982669/job/19678216617